### PR TITLE
Add keyboard-controlled triple countdown timer page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vanishing Ruins Timer</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <h1 class="title">Vanishing Ruins Timer</h1>
+      <section class="timers">
+        <article class="timer" data-index="0">
+          <h2 class="timer-label">Timer 1</h2>
+          <div class="timer-display" aria-live="polite">01:00</div>
+        </article>
+        <article class="timer" data-index="1">
+          <h2 class="timer-label">Timer 2</h2>
+          <div class="timer-display" aria-live="polite">01:00</div>
+        </article>
+        <article class="timer" data-index="2">
+          <h2 class="timer-label">Timer 3</h2>
+          <div class="timer-display" aria-live="polite">01:00</div>
+        </article>
+      </section>
+      <p class="instructions">Press 1, 2, or 3 to start or restart the matching timer.</p>
+    </main>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,79 @@
+(function () {
+  const DURATION_SECONDS = 60;
+
+  const timers = Array.from(document.querySelectorAll('.timer')).map(
+    (timerElement) => ({
+      element: timerElement,
+      display: timerElement.querySelector('.timer-display'),
+      duration: DURATION_SECONDS,
+      remaining: DURATION_SECONDS,
+      intervalId: null,
+      flashTimeout: null,
+    })
+  );
+
+  function formatTime(totalSeconds) {
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  function updateDisplay(timer) {
+    timer.display.textContent = formatTime(timer.remaining);
+  }
+
+  function clearTimer(timer) {
+    if (timer.intervalId !== null) {
+      clearInterval(timer.intervalId);
+      timer.intervalId = null;
+    }
+    if (timer.flashTimeout !== null) {
+      clearTimeout(timer.flashTimeout);
+      timer.flashTimeout = null;
+    }
+  }
+
+  function removeHighlight(timer) {
+    timer.element.classList.remove('expired');
+  }
+
+  function startTimer(index) {
+    const timer = timers[index];
+    if (!timer) return;
+
+    clearTimer(timer);
+    removeHighlight(timer);
+
+    timer.remaining = timer.duration;
+    updateDisplay(timer);
+
+    timer.intervalId = window.setInterval(() => {
+      timer.remaining -= 1;
+      if (timer.remaining <= 0) {
+        timer.remaining = 0;
+        updateDisplay(timer);
+        finishTimer(timer);
+      } else {
+        updateDisplay(timer);
+      }
+    }, 1000);
+  }
+
+  function finishTimer(timer) {
+    clearTimer(timer);
+    timer.element.classList.add('expired');
+    timer.flashTimeout = window.setTimeout(() => {
+      removeHighlight(timer);
+      timer.flashTimeout = null;
+    }, 1000);
+  }
+
+  document.addEventListener('keydown', (event) => {
+    if (['1', '2', '3'].includes(event.key)) {
+      const index = Number(event.key) - 1;
+      startTimer(index);
+    }
+  });
+
+  timers.forEach(updateDisplay);
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,92 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #111217;
+  color: #f5f5f5;
+}
+
+.app {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  align-items: center;
+}
+
+.title {
+  font-size: clamp(2rem, 3vw + 1rem, 3.5rem);
+  margin: 0;
+  letter-spacing: 0.08em;
+}
+
+.timers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: center;
+}
+
+.timer {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1.5rem 2rem;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+  border: 2px solid transparent;
+}
+
+.timer-label {
+  font-size: 1.1rem;
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+}
+
+.timer-display {
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.1em;
+}
+
+.timer.expired {
+  background: #862525;
+  border-color: #ff5a5a;
+}
+
+.timer.expired .timer-display {
+  animation: flash 0.5s ease-in-out 2;
+}
+
+.instructions {
+  margin: 0;
+  font-size: 1rem;
+  opacity: 0.75;
+}
+
+@keyframes flash {
+  from {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+  to {
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple centered layout with three labeled timers and instructions
- style the page with a dark theme and prominent timer displays that flash red on expiry
- implement JavaScript logic to start or reset each 1-minute timer via the 1, 2, or 3 keys and highlight expiration

## Testing
- Manual testing in browser

------
https://chatgpt.com/codex/tasks/task_e_68e5f4e33b0483228736e2ec4031dd9e