### PR TITLE
Adjust title emphasis to keep focus on timers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -26,7 +26,8 @@ body {
 }
 
 .title {
-  font-size: clamp(2rem, 3vw + 1rem, 3.5rem);
+  font-size: clamp(1.5rem, 2vw + 0.8rem, 2.5rem);
+  font-weight: 400;
   margin: 0;
   letter-spacing: 0.08em;
 }


### PR DESCRIPTION
## Summary
- reduce the main page title size and weight so the timer blocks remain the primary focus

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e61a06984c832298ea7de206d3e508