### PR TITLE
Add tooltip to pupin credit line

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,13 @@
         keyboard, or tap the blocks themselves.
       </p>
       <footer class="credits">
-        made by pupin of KOR-SEA #763, ID 117146728 of KingShot
+        made by
+        <span
+          class="credit-name"
+          data-tooltip="Please give me the Go! sticker. Otherwise, I will just have to say &quot;Waaaa!&quot; everytime"
+          >pupin</span
+        >
+        of KOR-SEA #763, ID 117146728 of KingShot
       </footer>
     </main>
     <script src="script.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -96,6 +96,62 @@ body {
   opacity: 0.6;
 }
 
+.credit-name {
+  position: relative;
+  color: #b3b7c6;
+  cursor: help;
+  transition: color 0.2s ease;
+}
+
+.credit-name:hover,
+.credit-name:focus-visible {
+  color: #d7dbe9;
+}
+
+.credit-name::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: 140%;
+  left: 50%;
+  transform: translateX(-50%) translateY(8px);
+  background: rgba(25, 27, 34, 0.95);
+  color: #f5f5f5;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  white-space: pre-line;
+  width: min(260px, 70vw);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.25);
+}
+
+.credit-name::before {
+  content: '';
+  position: absolute;
+  bottom: 115%;
+  left: 50%;
+  transform: translateX(-50%) scaleY(0);
+  border-width: 6px;
+  border-style: solid;
+  border-color: rgba(25, 27, 34, 0.95) transparent transparent transparent;
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.credit-name:hover::after,
+.credit-name:focus-visible::after,
+.credit-name:hover::before,
+.credit-name:focus-visible::before {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.credit-name:hover::before,
+.credit-name:focus-visible::before {
+  transform: translateX(-50%) scaleY(1);
+}
+
 @keyframes timer-activate {
   0% {
     transform: scale(1);


### PR DESCRIPTION
## Summary
- wrap the "pupin" credit in a tooltip-enabled span with the requested message
- add styling to display the tooltip on hover/focus and tint the name a soft grey

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e61c620ef88322bfa435725cb5a8cf