### PR TITLE
Make credits text fully opaque

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -93,7 +93,7 @@ body {
 .credits {
   margin: 0;
   font-size: 0.9rem;
-  opacity: 0.6;
+  color: #f5f5f5;
 }
 
 .credit-name {


### PR DESCRIPTION
## Summary
- ensure the credits footer uses a solid text color instead of reduced opacity for better readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e61f608a3c8322b3ad1b8941c9a67e