### PR TITLE
Make credit tooltip background fully opaque

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -114,7 +114,7 @@ body {
   bottom: 140%;
   left: 50%;
   transform: translateX(-50%) translateY(8px);
-  background: rgba(25, 27, 34, 0.95);
+  background: #191b22;
   color: #f5f5f5;
   padding: 0.5rem 0.75rem;
   border-radius: 0.5rem;
@@ -134,7 +134,7 @@ body {
   transform: translateX(-50%) scaleY(0);
   border-width: 6px;
   border-style: solid;
-  border-color: rgba(25, 27, 34, 0.95) transparent transparent transparent;
+  border-color: #191b22 transparent transparent transparent;
   opacity: 0;
   transition: opacity 0.2s ease, transform 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- update the credit tooltip background and pointer to use a fully opaque color

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6209ac3a883228940501b9e3131f4